### PR TITLE
Add initial CMake project layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.27)
+project(RGBStreamer LANGUAGES CXX)
+
+# Automatically detect vcpkg toolchain
+if(NOT DEFINED CMAKE_TOOLCHAIN_FILE AND DEFINED ENV{VCPKG_ROOT})
+    set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
+endif()
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_subdirectory(src)
+add_subdirectory(tests)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(RGBStreamer main.cpp)
+
+# Link required libraries
+find_package(nlohmann_json CONFIG REQUIRED)
+
+# Windows-specific libraries
+if (WIN32)
+    target_link_libraries(RGBStreamer PRIVATE nlohmann_json::nlohmann_json d3d11 dxgi ws2_32)
+else()
+    target_link_libraries(RGBStreamer PRIVATE nlohmann_json::nlohmann_json)
+endif()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,4 @@
+#include <nlohmann/json.hpp>
+int main() {
+    return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+# Add tests here in the future


### PR DESCRIPTION
## Summary
- initialize CMake build system using C++20 and vcpkg auto-detection
- create executable target `RGBStreamer`
- add `src` and `tests` subdirectories
- link against `nlohmann_json`, `d3d11`, `dxgi` and `ws2_32`
- provide a minimal `main.cpp` implementation